### PR TITLE
Update flake8 version to 5.0.4 in pre commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         ]
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     -   id: flake8
         args: ['--config=.flake8']


### PR DESCRIPTION
Update flake8 version to 5.0.4 in pre-commit configuration

* Update the `rev` field for the flake8 hook in the `.pre-commit-config.yaml` file from 4.0.1 to 5.0.4

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Bigcrosoft/DeepSpeed/pull/8?shareId=9a836fc4-182c-457a-a28d-47b7222d2e90).